### PR TITLE
Display secret key when generating a new wallet

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -836,7 +836,9 @@ bool simple_wallet::new_wallet(const std::string &wallet_file, const std::string
 
     logger(INFO, BRIGHT_WHITE) <<
       "Generated new wallet: " << m_wallet->getAddress() << std::endl <<
-      "view key: " << Common::podToHex(keys.viewSecretKey);
+      "View secret key: " << Common::podToHex(keys.viewSecretKey) << std::endl <<
+      "Spend secret key: " << Common::podToHex(keys.spendSecretKey);
+
   }
   catch (const std::exception& e) {
     fail_msg_writer() << "failed to generate new wallet: " << e.what();


### PR DESCRIPTION
Previously, a user would only see the new wallet address and view key when generating a new wallet. The user would need to enter the export_keys to then see the secret key.